### PR TITLE
Add CMS docs and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Holden's Garden
+
+This static site uses **Decap CMS** for content management. Open [the CMS](./admin/) to edit posts and pages.
+
+### Local development
+
+1. Clone the repository.
+2. Run a simple HTTP server (e.g., `python -m http.server`) and open the site.
+3. Use `/admin/` to login to Decap CMS.
+
+Uploads are stored in `assets/uploads` and committed via GitHub.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
   <body>
     <h1>Welcome to Holden's Garden</h1>
     <p>This site is powered by GitHub Pages and Decap CMS.</p>
-    <p><a href="/admin/">Go to CMS Admin</a></p>
+    <p><a href="/admin/">Go to CMS admin</a></p>
   </body>
 </html>

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,13 @@
+import os
+
+REQUIRED_DIRS = [
+    'admin',
+    'pages',
+    'posts',
+    'assets/uploads'
+]
+
+def test_required_directories_exist():
+    for directory in REQUIRED_DIRS:
+        assert os.path.isdir(directory), f"Missing required directory: {directory}"
+


### PR DESCRIPTION
## Summary
- capitalize CMS link correctly
- create an uploads directory for Decap CMS
- document local CMS usage
- add a pytest check for required directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bf809e30832e9617fbacf07a7453